### PR TITLE
Add nightly CI workflow building against WLED main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: usermod
+          persist-credentials: false
 
       - name: Checkout WLED
         uses: actions/checkout@v6
         with:
           repository: wled/WLED
           path: WLED
+          persist-credentials: false
 
       - name: Cache PlatformIO packages
         uses: actions/cache@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build against WLED
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  schedule:
+    - cron: '0 4 * * *'   # nightly at 04:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout usermod
+        uses: actions/checkout@v6
+        with:
+          path: usermod
+
+      - name: Checkout WLED
+        uses: actions/checkout@v6
+        with:
+          repository: wled/WLED
+          path: WLED
+
+      - name: Cache PlatformIO packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.platformio
+          key: pio-esp32-${{ hashFiles('WLED/platformio.ini') }}
+          restore-keys: pio-esp32-
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Configure usermod build
+        run: |
+          printf '[env:ci]\nextends = env:esp32dev\ncustom_usermods = file://${{ github.workspace }}/usermod\n' \
+            >> WLED/platformio_override.ini
+
+      - name: Build
+        run: platformio run -d WLED -e ci


### PR DESCRIPTION
Add a CI workflow to help keep out-of-tree usermods fresh.  By default, does nightly build against WLED main, providing an early warning if a breaking change gets merged.

Template users are free to customize however they like, but we can start with encouraging good maintenance practices.

Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated build workflow to validate the project against WLED on pushes, pull requests, nightly schedules, and manual runs.
  * Introduced a CI build environment that includes the custom usermod for integration testing.
  * Enabled caching of PlatformIO packages to speed up repeated builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/wled-usermod-example/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->